### PR TITLE
Add Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,33 @@
+# Use python as the base image
+FROM selenium/standalone-chrome
+
+# Install ruby
+USER root
+RUN \
+  sudo apt-get update && \
+  sudo apt-get install -y ruby ruby-dev git python3-pip 
+
+# Install pip/selenium
+RUN python3 -m pip install selenium
+
+# Install southwest-headers
+RUN mkdir /home/swcheckin
+RUN mkdir /home/swcheckin/data
+WORKDIR /home/swcheckin
+RUN git clone https://github.com/byalextran/southwest-headers.git
+RUN \
+  cd /home/swcheckin/southwest-headers && \
+  pip install -r requirements.txt
+# Modify chromedriver
+RUN sudo perl -pi -e 's/cdc_/swc_/g' /usr/bin/chromedriver
+RUN ln -s /usr/bin/chromedriver /home/swcheckin/southwest-headers/chromedriver
+
+# Install southwest-checkin
+WORKDIR /home/swcheckin
+RUN git clone https://github.com/byalextran/southwest-checkin.git
+ADD ./runner.sh /home/swcheckin
+
+
+ENTRYPOINT ["/home/swcheckin/runner.sh"]
+
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM selenium/standalone-chrome
 USER root
 RUN \
   sudo apt-get update && \
-  sudo apt-get install -y ruby ruby-dev git python3-pip 
+  sudo apt-get install -y ruby ruby-dev git python3-pip at
 
 # Install pip/selenium
 RUN python3 -m pip install selenium

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+version: "3"
+services:
+  southwest-checkin:
+    container_name: southwest_checkin
+    restart: always
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: southwest-checkin
+    environment:
+      LUV_HEADERS_FILE: /home/swcheckin/data/southwest_headers.json
+      LUV_FROM_EMAIL: from@email.com
+      LUV_USER_NAME: from@email.com
+      LUV_PASSWORD: supersecurepassword
+      LUV_SMTP_SERVER: smtp.email.com
+      LUV_PORT: 587
+    command: ["/home/swcheckin/runner.sh"]
+

--- a/runner.sh
+++ b/runner.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+## Initial starup getting sw headers
+echo "---- Creating Southwest Headers ----"
+cd /home/swcheckin/southwest-headers && \
+python3 southwest-headers.py /home/swcheckin/data/southwest_headers.json
+echo "---- Creation Finished ----"
+
+## Setup gem
+cd /home/swcheckin/southwest-checkin && \
+gem install autoluv
+
+## Now loop the header updates
+while true
+do  
+    sleep 1d
+    echo "---- Updating Southwest Headers ----"
+    cd /home/swcheckin/southwest-headers && \
+    python3 southwest-headers.py /home/swcheckin/data/southwest_headers.json
+    echo "---- Updating Finished.  Waiting 24 hours ----"
+done

--- a/runner.sh
+++ b/runner.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+#start ATD
+service atd start
+
 ## Initial starup getting sw headers
 echo "---- Creating Southwest Headers ----"
 cd /home/swcheckin/southwest-headers && \


### PR DESCRIPTION
Create a new docker image to standardize the environment.

I wasn't quite brave enough to book a refundable flight to fully test it out.  I have one next week to use it on.  Did test the email and that seems to all be working properly.

### Installation:

Choose one:

 **a) Straight Docker**
`docker build -t southwest-checkin .`
`docker run -d  -e LUV_HEADERS_FILE='/home/swcheckin/data/southwest_headers.json' -e LUV_FROM_EMAIL='from@email.com' -e LUV_USER_NAME='from@email.com' -e LUV_PASSWORD='supersecurepassword' -e LUV_SMTP_SERVER='smtp.email.com' -e LUV_PORT=587 southwest-checkin`

**b) Docker-Compose**
edit _docker-compose.yml_ with your SMTP variables
`docker-compose up -d --no-deps --build southwest-checkin`

### Add check-in schedule:

Wait a minute or so for the header file to be created after starting the container:

`docker exec -it <dockerproc> /bin/sh -c "autoluv schedule AAAAAA Fake Name real@email.com"`
